### PR TITLE
Add CI (fmt, clippy, test, example build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  lint:
+    name: fmt & clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo test
+        run: cargo test --workspace --all-targets
+
+  example:
+    name: build example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: example
+      - name: install cargo-about
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-about
+      - name: cargo build (example)
+        working-directory: example
+        run: cargo build
+      - name: cargo run (example)
+        working-directory: example
+        run: cargo run -- --help


### PR DESCRIPTION
## 概要

このリポジトリに CI が無かったため、PR / push 時に走る基本的な CI を追加します。

## 内容

- `lint` ジョブ: `cargo fmt --all -- --check` + `cargo clippy --workspace --all-targets -- -D warnings`
- `test` ジョブ: `cargo test --workspace --all-targets`
- `example` ジョブ: cargo-about をインストールし、workspace から exclude されている `example` を build & `--help` 実行（ビルドパイプライン全体の統合チェック）

## 補足

- このPRは **Linux (ubuntu-latest)** のCI。Windows matrix は #11 で別途追加します（#9 は #8 のライブラリ API 化で解消済みのため、Windows ジョブは回帰テストとして緑で入る想定）。
- `Cargo.lock` は `.gitignore` 済み（ライブラリ workspace）なのでコミットしていません。

> 注: 当初含めていた clippy 修正コミットは、#8（library API 化）が当該コードを置き換えて不要になったためリベースで除外し、このPRは ci.yml の追加のみになっています。
