### PR TITLE
ci: add windows-latest to the example build matrix (#9 regression test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,11 @@ jobs:
 
   example:
     name: build example
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## 概要

`example` ビルドジョブに `windows-latest` を追加し、CI を Linux + Windows の matrix にします。

## 位置づけ（#9 の回帰テスト）

- #9（cargo-about 0.9+ が PowerShell 配下で stdout パイプ出力を拒否して panic）は **#8（cargo-about を library API 直叩きに移行）で解消済み**。
- この Windows ジョブはその **回帰テスト**: 将来サブプロセス実行が復活するなどして #9 が再発したら、CI で検知できる。
- `fail-fast: false` なので Linux ジョブは Windows の結果に巻き込まれず完走します。

> 経緯: 当初は #9 を再現する「意図的に RED」の PR でしたが、#8 マージ後に main へリベースした結果 Windows ジョブも PASS するようになり、回帰テストとして機能しています。
