### PR TITLE
Apply cargo fmt

### DIFF
--- a/notalawyer-build/src/lib.rs
+++ b/notalawyer-build/src/lib.rs
@@ -54,7 +54,9 @@ pub fn build() {
     let store = cargo_about::licenses::store_from_cache().expect("failed to load license store");
 
     // Create HTTP client for fetching license information from remote sources
-    let client = reqwest::blocking::ClientBuilder::new().build().expect("failed to create HTTP client");
+    let client = reqwest::blocking::ClientBuilder::new()
+        .build()
+        .expect("failed to create HTTP client");
 
     let summary = cargo_about::licenses::Gatherer::with_store(Arc::new(store))
         .with_confidence_threshold(0.8)
@@ -105,7 +107,12 @@ fn render_license_list(license_list: &cargo_about::generate::LicenseList<'_>) ->
             let link = crate_link(&krate.name, krate.repository.as_deref());
             writeln!(output, "  - {} {} ({link})", krate.name, krate.version).unwrap();
         }
-        writeln!(output, "\n{}\n--------------------------------------------------------------------------", license.text).unwrap();
+        writeln!(
+            output,
+            "\n{}\n--------------------------------------------------------------------------",
+            license.text
+        )
+        .unwrap();
     }
     output
 }


### PR DESCRIPTION
## 概要

main に残っていた未整形コード（#8 のライブラリ API 化で入った `notalawyer-build/src/lib.rs` の2箇所）に `cargo fmt` を当てます。

これで CI の `fmt & clippy` ジョブが緑になります（#10 で CI を入れた直後はこの fmt 負債で赤でした）。整形のみで挙動の変更はありません。

## 差分

- `reqwest::blocking::ClientBuilder` のメソッドチェーンを複数行に
- `render_license_list` 内の長い `writeln!` を複数行に
