### PR TITLE
ci: test the example build on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要

`example` ビルドジョブの matrix に `macos-latest` を追加し、Linux / Windows / macOS の3 OS で example の build & `--license-notice` 実行を検証します。

## 動機

#9 のように OS 依存の問題（cargo-about / reqwest のビルド経路）が起こり得るため、macOS でも通ることを CI で担保しておきます。`fail-fast: false` なので他 OS のジョブは巻き込まれません。