### PR TITLE
docs: 公開APIにrustdocを追加

### DIFF
--- a/notalawyer-build/src/lib.rs
+++ b/notalawyer-build/src/lib.rs
@@ -1,3 +1,36 @@
+//! Build-time generation of dependency license notices.
+//!
+//! This crate is the build-script half of the `notalawyer` family. Called from
+//! a crate's `build.rs`, [`build`] gathers the license texts of all
+//! dependencies (using the [`cargo_about`] library) and writes a single
+//! `NOTICE` file into `OUT_DIR`.
+//!
+//! The other two crates consume that file at compile time and runtime:
+//!
+//! - **`notalawyer-build`** (this crate) writes the `NOTICE` file from
+//!   `build.rs`.
+//! - [`notalawyer`](https://docs.rs/notalawyer) embeds it via
+//!   `include_notice!`.
+//! - [`notalawyer-clap`](https://docs.rs/notalawyer-clap) exposes it behind a
+//!   `--license-notice` CLI flag.
+//!
+//! License acceptance and gathering are configured through an `about.toml`
+//! file, searched for from the consuming crate's manifest directory upward;
+//! see [cargo-about](https://embarkstudios.github.io/cargo-about/) for its
+//! format.
+//!
+//! # Example
+//!
+//! Add `notalawyer-build` as a build dependency and call [`build`] from the
+//! `main` of your `build.rs`:
+//!
+//! ```no_run
+//! // build.rs
+//! println!("cargo:rerun-if-changed=Cargo.toml");
+//!
+//! notalawyer_build::build();
+//! ```
+
 use std::path::Path;
 use std::sync::Arc;
 
@@ -21,6 +54,34 @@ fn load_config(manifest_path: &camino::Utf8Path) -> cargo_about::licenses::confi
     cargo_about::licenses::config::Config::default()
 }
 
+/// Gather dependency licenses and write the `NOTICE` file into `OUT_DIR`.
+///
+/// Intended to be called from a `build.rs`. It:
+///
+/// 1. Locates an `about.toml` config by walking up from the consuming crate's
+///    `CARGO_MANIFEST_DIR` (falling back to defaults if none is found).
+/// 2. Resolves the dependency graph and gathers each crate's license text via
+///    the [`cargo_about`] library.
+/// 3. Renders a combined notice and writes it to `$OUT_DIR/notalawyer`, the
+///    path that [`notalawyer::include_notice!`](https://docs.rs/notalawyer)
+///    later embeds.
+///
+/// It also emits `cargo:rerun-if-changed=about.toml` so the notice is
+/// regenerated when the config changes.
+///
+/// # Panics
+///
+/// Panics if `OUT_DIR` or `CARGO_MANIFEST_DIR` are unset (i.e. when not run as
+/// a build script), or if gathering, resolving, or writing the licenses fails.
+///
+/// # Example
+///
+/// ```no_run
+/// // build.rs
+/// println!("cargo:rerun-if-changed=Cargo.toml");
+///
+/// notalawyer_build::build();
+/// ```
 pub fn build() {
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
     let license_path = Path::new(&out_dir).join("notalawyer");

--- a/notalawyer-clap/src/lib.rs
+++ b/notalawyer-clap/src/lib.rs
@@ -1,6 +1,100 @@
+//! [`clap`] integration for displaying dependency license notices.
+//!
+//! This crate is the CLI-facing layer of the `notalawyer` family. It adds a
+//! `--license-notice` flag to any [`clap::Parser`] command via the [`ParseExt`]
+//! extension trait, printing the embedded notice and exiting when the flag is
+//! present.
+//!
+//! It works together with the other two crates:
+//!
+//! - [`notalawyer-build`](https://docs.rs/notalawyer-build) generates the
+//!   `NOTICE` file from a `build.rs`.
+//! - [`notalawyer`](https://docs.rs/notalawyer) embeds it via
+//!   [`include_notice!`], which is re-exported here for convenience.
+//! - **`notalawyer-clap`** (this crate) feeds that string to
+//!   [`ParseExt::parse_with_license_notice`].
+//!
+//! # Example
+//!
+//! ```ignore
+//! use clap::Parser;
+//! use notalawyer_clap::*;
+//!
+//! #[derive(Parser)]
+//! struct Args {
+//!     #[clap(long)]
+//!     flag: bool,
+//! }
+//!
+//! fn main() {
+//!     // `include_notice!()` provides the embedded `&'static str`; the helper
+//!     // adds a `--license-notice` flag that prints it and exits.
+//!     let _args = Args::parse_with_license_notice(include_notice!());
+//! }
+//! ```
+
+/// Re-export of [`notalawyer::include_notice!`] so callers can depend on this
+/// crate alone.
+///
+/// Use it to produce the `&str` argument for
+/// [`ParseExt::parse_with_license_notice`]:
+///
+/// ```ignore
+/// use notalawyer_clap::include_notice;
+///
+/// let notice: &'static str = include_notice!();
+/// ```
 pub use notalawyer::include_notice;
 
+/// Extension trait that adds a `--license-notice` flag to any [`clap::Parser`].
+///
+/// A blanket implementation covers every type that implements
+/// [`clap::Parser`], so deriving `Parser` is enough to gain
+/// [`parse_with_license_notice`](ParseExt::parse_with_license_notice).
+///
+/// # Example
+///
+/// ```ignore
+/// use clap::Parser;
+/// use notalawyer_clap::*;
+///
+/// #[derive(Parser)]
+/// struct Args {
+///     #[clap(long)]
+///     flag: bool,
+/// }
+///
+/// // `Args` automatically gains `parse_with_license_notice` via the blanket impl.
+/// let _args = Args::parse_with_license_notice(include_notice!());
+/// ```
 pub trait ParseExt: clap::Parser {
+    /// Parse the process arguments, adding a `--license-notice` flag.
+    ///
+    /// This behaves like [`clap::Parser::parse`], except that the command is
+    /// augmented with a `--license-notice` flag. When that flag is passed,
+    /// `notice` is printed to stdout and the process exits with status `0`
+    /// before any of the parser's own fields are produced. Otherwise the
+    /// arguments are parsed and the resulting value is returned (errors are
+    /// formatted and reported through clap's usual exit path).
+    ///
+    /// `notice` is typically produced by [`include_notice!`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use clap::Parser;
+    /// use notalawyer_clap::*;
+    ///
+    /// #[derive(Parser)]
+    /// struct Args {
+    ///     #[clap(long)]
+    ///     flag: bool,
+    /// }
+    ///
+    /// // With `--license-notice`, this prints the notice and exits;
+    /// // otherwise it returns the parsed `Args`.
+    /// let _args = Args::parse_with_license_notice(include_notice!());
+    /// ```
     fn parse_with_license_notice(notice: &str) -> Self {
         fn patch_command(cmd: clap::Command) -> clap::Command {
             cmd.arg(clap::arg!(--"license-notice" "Show license notices"))

--- a/notalawyer/src/lib.rs
+++ b/notalawyer/src/lib.rs
@@ -1,3 +1,58 @@
+//! Embed and access the license notices of a crate's dependencies.
+//!
+//! `notalawyer` is the runtime core of a three-crate family that lets a binary
+//! display the license notices of every crate it depends on:
+//!
+//! - [`notalawyer-build`](https://docs.rs/notalawyer-build) runs from a
+//!   `build.rs`, gathers the dependency licenses, and writes a `NOTICE` file
+//!   into `OUT_DIR`.
+//! - **`notalawyer`** (this crate) provides the [`include_notice!`] macro, which
+//!   embeds that generated `NOTICE` file into the binary as a `&'static str`.
+//! - [`notalawyer-clap`](https://docs.rs/notalawyer-clap) wires the notice into
+//!   a [`clap`](https://docs.rs/clap) CLI behind a `--license-notice` flag.
+//!
+//! This crate has no dependencies and exposes only the [`include_notice!`]
+//! macro.
+//!
+//! # Example
+//!
+//! ```ignore
+//! // The build script (notalawyer-build) wrote a NOTICE file into OUT_DIR.
+//! // `include_notice!` embeds it as a `&'static str` at compile time.
+//! let notice: &'static str = notalawyer::include_notice!();
+//! print!("{notice}");
+//! ```
+
+/// Embed the generated dependency-license `NOTICE` file as a `&'static str`.
+///
+/// This macro expands to an [`include_str!`] of the `NOTICE` file that
+/// [`notalawyer-build`](https://docs.rs/notalawyer-build) writes into `OUT_DIR`
+/// at build time. Because it reads `OUT_DIR`, it only compiles in a crate whose
+/// `build.rs` calls `notalawyer_build::build()`.
+///
+/// The expansion is purely a compile-time `include_str!`, so the notice text is
+/// baked into the binary with no runtime file access.
+///
+/// # Example
+///
+/// Pair it with [`notalawyer-clap`](https://docs.rs/notalawyer-clap) to expose
+/// the notice through a CLI flag:
+///
+/// ```ignore
+/// use clap::Parser;
+/// use notalawyer_clap::*;
+///
+/// #[derive(Parser)]
+/// struct Args {
+///     #[clap(long)]
+///     flag: bool,
+/// }
+///
+/// fn main() {
+///     // Running the binary with `--license-notice` prints the embedded notice.
+///     let _args = Args::parse_with_license_notice(include_notice!());
+/// }
+/// ```
 #[macro_export]
 macro_rules! include_notice {
     () => {


### PR DESCRIPTION
## 概要

3つのクレートすべての公開APIに rustdoc を追加します。各クレートにクレートレベルの `//!` ドキュメントを付け、3つのクレートがどのように連携するかを説明したうえで、公開API項目に使用例つきの `///` ドキュメントを追加しました。

## 変更内容

- **notalawyer**: `include_notice!` マクロを文書化。ビルド時に `OUT_DIR` に生成された `NOTICE` を `include_str!` で埋め込むことを説明。
- **notalawyer-clap**: `ParseExt` トレイトと `parse_with_license_notice`（`--license-notice` フラグを追加するメソッド）、および `include_notice` の re-export を文書化。
- **notalawyer-build**: `build()` 関数を文書化。`about.toml` を読み、cargo-about ライブラリで依存先のライセンスを収集し、`OUT_DIR` に `NOTICE` を書き出す流れを説明。プライベートなヘルパー関数にはドキュメントを追加していません。

## doctest について

これらのAPIはビルドスクリプト / マクロ / clap の文脈でのみ動作するため、例はそのままでは単体実行できません。`include_notice!()` を呼ぶ例は `OUT_DIR` がコンパイル時に未定義になるため `ignore`、`build.rs` 相当の例は `no_run` を使用し、doc-test がコンパイル・実行を通るようにしました（失敗する doctest は導入していません）。

## 確認

ワークツリーのルートから以下を実行し、すべて成功することを確認しました（`cargo fmt` は実行していません）。

- `cargo build`: 成功
- `cargo doc --no-deps`: 生成成功
- `cargo test --doc`: 0 failures（doctest 8件: ignored 6 / compile-only 2）
- `cargo clippy --workspace --all-targets -- -D warnings`: 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)