### PR TITLE
ci: pin actions to minor.patch versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     name: fmt & clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy
@@ -28,9 +28,9 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: cargo test
         run: cargo test --workspace --all-targets
 
@@ -42,13 +42,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: example
       - name: install cargo-about
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
           tool: cargo-about
       - name: cargo build (example)


### PR DESCRIPTION
## 概要

SHA 固定済みの GitHub Actions について、末尾コメントのバージョンを **minor.patch まで**明示します。Renovate はこのコメント（currentValue）を見て更新粒度を決めるため、`# v4`(major) だと major 追従、`# v4.3.1`(minor.patch) にすると minor.patch 単位で更新を提案するようになります。

## 変更

- `actions/checkout`: `# v4` → `# v4.3.1`（SHA 同一）
- `Swatinem/rust-cache`: `# v2` → `# v2.9.1`（**SHA も v2.9.1 リリースの SHA に再固定**。従来の SHA はタグ付きリリースに対応していなかったため）
- `taiki-e/install-action`: `# v2` → `# v2.81.10`（SHA 同一）

## 対象外

- `dtolnay/rust-toolchain@stable`: semver リリースを持たない rolling tag のため minor.patch 固定の対象外。`@stable` のまま据え置き。

> この PR を先に入れてから #20 (actions/checkout v6) を取り込むと、checkout が minor.patch 粒度で更新されます。