### PR TITLE
notalawyer-build: gate remote clarify.git fetch behind default `fetch-clarify-license` feature

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -676,7 +676,9 @@ dependencies = [
  "cargo-about",
  "codespan-reporting",
  "krates",
+ "rustls",
  "toml-span",
+ "ureq",
 ]
 
 [[package]]

--- a/notalawyer-build/Cargo.toml
+++ b/notalawyer-build/Cargo.toml
@@ -9,9 +9,27 @@ description.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["fetch-clarify-license"]
+# Construct a `ureq::Agent` and hand it to cargo-about so it can fetch remote
+# license files for `[clarify.<crate>.git]` entries in `about.toml`. Disable
+# (`--no-default-features`) for a fully offline build, e.g. on docs.rs.
+fetch-clarify-license = ["dep:ureq", "dep:rustls"]
+
 [dependencies]
 cargo-about = { version = "0.9", default-features = false }
 camino = "1.2"
 krates = "0.21"
 toml-span = "0.7"
 codespan-reporting = "0.13"
+# These mirror the exact versions/features cargo-about 0.9 uses for its own
+# HTTP client, so the `ureq::Agent` type unifies with what `Gatherer::gather`
+# expects. Both are already transitive dependencies of cargo-about, so enabling
+# `fetch-clarify-license` adds no new crates to the dependency graph.
+ureq = { version = "3.3", optional = true, default-features = false, features = [
+    "platform-verifier",
+    "rustls-no-provider",
+] }
+rustls = { version = "0.23", optional = true, default-features = false, features = [
+    "ring",
+] }

--- a/notalawyer-build/src/lib.rs
+++ b/notalawyer-build/src/lib.rs
@@ -125,11 +125,35 @@ pub fn build() {
 
     // cargo-about 0.9 takes an optional `ureq::Agent` for fetching remote
     // license information (clearlydefined.io, the original git repos for crates
-    // that were packaged without their LICENSE files, ...). The standard
-    // licenses we accept (MIT / Apache-2.0 / Unicode-DFS-2016) are all covered
-    // by the embedded license store loaded above, so we run fully offline by
-    // passing `None`: no network access happens at build time and we don't have
-    // to wire up a TLS provider ourselves.
+    // that were packaged without their LICENSE files, ...). This is what backs
+    // `[clarify.<crate>.git]` entries in `about.toml`.
+    //
+    // The `fetch-clarify-license` feature (enabled by default) decides whether
+    // we hand cargo-about such an agent. When it is on we build the agent the
+    // same way cargo-about's own CLI does, so the type unifies with what
+    // `Gatherer::gather` expects. When it is off (`--no-default-features`) we
+    // pass `None` and run fully offline -- handy for docs.rs or any sandboxed
+    // build with no network access. Constructing the agent does not perform any
+    // network access by itself; fetches only happen for `clarify.git` entries.
+    #[cfg(feature = "fetch-clarify-license")]
+    let client = {
+        use ureq::tls::{RootCerts, TlsConfig};
+
+        let prov = rustls::crypto::ring::default_provider();
+
+        Some(
+            ureq::Agent::config_builder()
+                .tls_config(
+                    TlsConfig::builder()
+                        .unversioned_rustls_crypto_provider(Arc::new(prov))
+                        .root_certs(RootCerts::PlatformVerifier)
+                        .build(),
+                )
+                .build()
+                .new_agent(),
+        )
+    };
+    #[cfg(not(feature = "fetch-clarify-license"))]
     let client = None;
 
     let summary = cargo_about::licenses::Gatherer::with_store(Arc::new(store))


### PR DESCRIPTION
Adds a default-enabled `fetch-clarify-license` feature to `notalawyer-build`: cargo-about's remote `clarify.git` license fetching keeps working by default, while `--no-default-features` makes the build fully offline (e.g. for docs.rs / sandboxed CI).

## 概要

#23 で cargo-about 0.9 へ移行した際、`Gatherer::gather` に渡す HTTP クライアントを `None`（オフライン）固定にした。これは `about.toml` の `[clarify.<crate>.git]`（publish パッケージに LICENSE を同梱していない crate の本文を git リポジトリから取得する設定）を無効化してしまう。本 PR はこれを **default 有効の feature** にし、通常はリモート取得が効き、必要なときだけオフラインにできるようにする。

## 変更点

- `fetch-clarify-license` feature を追加（`default = ["fetch-clarify-license"]`）
- 有効時: cargo-about CLI と同じ方法で `ureq::Agent`(rustls/ring) を構築し `gather` に `Some(agent)` を渡す
- 無効時(`--no-default-features`): `None`＝完全オフライン
- `ureq` / `rustls` を optional 依存として追加

## 判断・トレードオフ

- **default 有効にした**: cargo-about 0.8.4（バイナリ実行）時代と同じ「clarify.git が効く」挙動を既定で維持する。#23 の Codex レビュー指摘（`None` 固定が clarify.git を退行させる）への対応。
- **`DOCS_RS` 環境検出ではなく feature にした**: docs.rs 以外のオフライン用途にも使える汎用スイッチにするため。`ureq::Agent` の構築自体はネットアクセスしない（実 fetch は clarify.git 処理時のみ）ので、clarify.git を使わないプロジェクトは default のままでも docs.rs で問題なくビルドできる。
- **依存は増えない**: `ureq` / `rustls` は cargo-about 0.9 が無条件に引く transitive 依存。optional な直接依存にしても新規 transitive クレートは増えず、型を名指しできるようにするだけ。

## 検証

- `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings` を **default・`--no-default-features` の両方**でクリーン
- `cargo test`（doctest 含む）pass
- example の `--license-notice` 出力が #23 時点と **byte 単位で一致**（example は clarify.git 不使用のため、Agent を構築しても出力は変わらない）
- CI: Linux / Windows / macOS すべて緑

## 関連

- #23 の Codex レビュー指摘を解消
- #6（docs.rs ビルド失敗）: `--no-default-features` で完全オフラインビルドが可能になる
