### PR TITLE
Declare MSRV (Rust 1.88)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,8 @@ version = "0.2.0"
 repository = "https://github.com/arkedge/notalawyer"
 license = "MIT"
 edition = "2021"
+# Driven by cargo-about 0.9 (used by notalawyer-build); verified to build on
+# 1.88 and fail on 1.86.
+rust-version = "1.88"
 readme = "README.md"
 description = "Utility library to display license notices"

--- a/notalawyer-build/Cargo.toml
+++ b/notalawyer-build/Cargo.toml
@@ -2,6 +2,7 @@
 name = "notalawyer-build"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/notalawyer-clap/Cargo.toml
+++ b/notalawyer-clap/Cargo.toml
@@ -2,6 +2,7 @@
 name = "notalawyer-clap"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/notalawyer/Cargo.toml
+++ b/notalawyer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "notalawyer"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true


### PR DESCRIPTION
Declares the workspace MSRV as **Rust 1.88**, driven by cargo-about 0.9 (via `notalawyer-build`). Verified empirically: builds on 1.88, fails on 1.86.

## 概要

これまで `rust-version` を宣言していなかった。0.3.0 リリースに向けて MSRV を明示する。

## 変更点

- `[workspace.package]` に `rust-version = "1.88"` を追加
- 各 crate（`notalawyer` / `notalawyer-clap` / `notalawyer-build`）で `rust-version.workspace = true` を付け、workspace 共通値を継承

## 判断・トレードオフ

- **1.88 の出どころ**: `notalawyer-build` が依存する cargo-about 0.9（`rust-version = 1.88.0`）。他の依存（clap / ureq = 1.85、rustls = 1.71、toml-span = 1.70 等）はすべてそれ未満なので、1.88 が束縛条件。
- **workspace 共通にした**: 厳密には `notalawyer`（依存ゼロ・edition 下限 1.56）や `notalawyer-clap`（clap 1.85）はより古い Rust でも動く。が、notalawyer を使う構成は実質 `notalawyer-build` も使うため実効 MSRV は 1.88 になる。一覧の単純さを優先し、メンテナ判断で workspace 共通とした。

## 検証（実測）

- `cargo +1.88.0 check --workspace` → **成功**
- `cargo +1.86.0 check --workspace` → **失敗**（`error: rustc 1.86.0 is not supported by ... cargo-about@0.9.0 requires rustc 1.88.0`）
- 参考: core 2 crate は `cargo +1.85.1 check -p notalawyer -p notalawyer-clap` で成功（1.88 は build crate 由来であることの裏付け）

## 関連

- cargo-about 0.9 移行（#23）に伴う MSRV 確定。0.3.0 リリースの前段として先に入れる。
