### PR TITLE
ci: add publish dry-run workflow

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,22 @@
+name: release dry-run
+
+# Dry-run `cargo publish` for the whole workspace to validate that every crate
+# packages and builds for release (in dependency order) before cutting one.
+# `--dry-run` uploads nothing.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish-dry-run:
+    name: cargo publish --dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo publish --dry-run --workspace


### PR DESCRIPTION
Adds a workflow that runs `cargo publish --dry-run --workspace` on push to `main` and on pull requests, to validate that every crate packages and builds for release (in dependency order) before cutting one. `--dry-run` uploads nothing.

## 変更点

- `.github/workflows/release-dry-run.yml` を追加（`push`(main) / `pull_request`、`cargo publish --dry-run --workspace`）

## 補足

- cargo 1.90+ の workspace publish は intra-workspace 依存を解決するため、未公開バージョン（例: 0.3.0）でも依存先（`notalawyer-clap`）の verify が local の crate で通る（ローカルで `cargo publish --dry-run --workspace` が EXIT=0 を確認済み）。