### PR TITLE
ci: drop the now-unused install cargo-about step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,6 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: example
-      - name: install cargo-about
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
-        with:
-          tool: cargo-about
       - name: cargo build (example)
         working-directory: example
         run: cargo build


### PR DESCRIPTION
example の CI ジョブから `install cargo-about` ステップを削除します。

#23 以降、`notalawyer-build` は cargo-about を**ライブラリ**として呼ぶようになり（`cargo about` バイナリの実行をやめた）、example のビルドにバイナリのインストールは不要になりました。この PR の CI が「バイナリ無しでも example がビルド・実行できる」ことを実証します。